### PR TITLE
Make `attribute Promise<T>[] attr;` work.

### DIFF
--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -214,8 +214,7 @@
                     ret.idlType = type() || error("Error parsing generic type " + value);
                     all_ws();
                     if (!consume(OTHER, ">")) error("Unterminated generic type " + value);
-                    all_ws();
-                    if (consume(OTHER, "?")) ret.nullable = true;
+                    type_suffix(ret);
                     return ret;
                 }
                 else {

--- a/test/syntax/idl/generic.widl
+++ b/test/syntax/idl/generic.widl
@@ -1,5 +1,6 @@
 interface Foo {
   Promise<ResponsePromise<sequence<DOMString?>>> bar();
+  readonly attribute Promise<DOMString>[] baz;
 };
 
 // Extracted from https://slightlyoff.github.io/ServiceWorker/spec/service_worker/ on 2014-05-08
@@ -14,4 +15,3 @@ interface ServiceWorkerClients {
 interface FetchEvent : Event {
   ResponsePromise<any> default();
 };
-

--- a/test/syntax/json/generic.json
+++ b/test/syntax/json/generic.json
@@ -45,6 +45,31 @@
                 "name": "bar",
                 "arguments": [],
                 "extAttrs": []
+            },
+            {
+                "type": "attribute",
+                "static": false,
+                "stringifier": false,
+                "inherit": false,
+                "readonly": true,
+                "idlType": {
+                    "sequence": false,
+                    "generic": "Promise",
+                    "nullable": false,
+                    "array": 1,
+                    "nullableArray": [false],
+                    "union": false,
+                    "idlType": {
+                        "sequence": false,
+                        "generic": null,
+                        "nullable": false,
+                        "array": false,
+                        "union": false,
+                        "idlType": "DOMString"
+                    }
+                },
+                "name": "baz",
+                "extAttrs": []
             }
         ],
         "inheritance": null,


### PR DESCRIPTION
This appears in the #attr-basic test case for ReSpec.

Fixes #19.