### PR TITLE
Add support for extended attributes identifier lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,9 +660,8 @@ The fields are as follows:
   whereas the lack thereof will yield a `null`. If there is an `rhs` field then
   they are the right-hand side's arguments, otherwise they apply to the extended
   attribute directly.
-* `rhs`: If there is a right-hand side, this will capture its `type` (always
-  "identifier" in practice, though it may be extended in the future) and its
-  `value`.
+* `rhs`: If there is a right-hand side, this will capture its `type` (which can be
+  "identifier" or "identifier-list") and its `value`.
 * `typePair`: If the extended attribute is a `MapClass` this will capture the
   map's key type and value type respectively.
 

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -336,6 +336,7 @@
                   ret.rhs = rhs
                 }
                 else if (consume(OTHER, "(")) {
+                    // [Exposed=(Window,Worker)]
                     rhs = [];
                     var id = consume(ID);
                     if (id) {
@@ -343,7 +344,10 @@
                     }
                     identifiers(rhs);
                     consume(OTHER, ")") || error("Unexpected token in extended attribute argument list or type pair");
-                    ret.rhs = rhs;
+                    ret.rhs = {
+                        type: "identifier-list",
+                        value: rhs
+                    };
                 }
                 if (!ret.rhs) return error("No right hand side to extended attribute assignment");
             }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "underscore": "1.7.0",
     "jsondiffpatch": "0.1.27",
     "benchmark": "*",
-    "microtime": "1.1.0"
+    "microtime": "1.4.1"
   },
   "scripts": {
     "test": "mocha"

--- a/test/syntax/idl/extended-attributes.widl
+++ b/test/syntax/idl/extended-attributes.widl
@@ -1,0 +1,6 @@
+// Extracted from http://www.w3.org/TR/2015/WD-service-workers-20150205/
+
+[Global=(Worker,ServiceWorker), Exposed=ServiceWorker]
+interface ServiceWorkerGlobalScope : WorkerGlobalScope {
+  
+};

--- a/test/syntax/json/extended-attributes.json
+++ b/test/syntax/json/extended-attributes.json
@@ -1,0 +1,30 @@
+[
+    {
+        "type": "interface",
+        "name": "ServiceWorkerGlobalScope",
+        "partial": false,
+        "members": [],
+        "inheritance": "WorkerGlobalScope",
+        "extAttrs": [
+            {
+                "name": "Global",
+                "arguments": null,
+                "rhs": {
+                    "type": "identifier-list",
+                    "value": [
+                        "Worker",
+                        "ServiceWorker"
+                    ]
+                }
+            },
+            {
+                "name": "Exposed",
+                "arguments": null,
+                "rhs": {
+                    "type": "identifier",
+                    "value": "ServiceWorker"
+                }
+            }
+        ]
+    }
+]


### PR DESCRIPTION
This adds support for constructs of the form:

```
[Exposed=(Window,Worker)]
```

which were kind of supported, but not documented.

The proposed JSON syntax for the above would be:

```json
{
    "name": "Exposed",
    "arguments": null,
    "rhs": {
        "type": "identifier-list",
        "value": [
            "Global",
            "Worker"
        ]
   }
}
```

This introduces a new Right Hand Side type, the [identifier list](http://heycam.github.io/webidl/#prod-ExtendedAttributeIdentList). I'm happy to change the JSON syntax, though, if so, please LMK.

Note that currently, the above would be rendered as:

```json
{
    "name": "Exposed",
    "arguments": null,
    "rhs": [
        "Global",
        "Worker"
    ]
}
```