### PR TITLE
Allow typedefs within interfaces (behind an opt-in flag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ In the browser:
       var tree = WebIDL2.parse("string of WebIDL");
     </script>
 
+Advanced Parsing
+----------------
+
+`parse()` can optionally accept a second parameter, an options object, which can be used to
+modify parsing behavior.
+
+The following options are recognized:
+```javascript
+{
+    allowNestedTypedefs: false # 
+}
+```
+And their meanings are as follows:
+
+* `allowNestedTypedefs`: Boolean indicating whether the parser should accept `typedef`s as valid members of `interface`s. This is non-standard syntax and therefore the default is `false`.
+
 Errors
 ------
 When there is a syntax error in the WebIDL, it throws an exception object with the following

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -710,11 +710,8 @@
                     consume(OTHER, ";") || error("Missing semicolon after interface");
                     return ret;
                 }
-
-
                 var ea = extended_attrs(store ? mems : null);
                 all_ws();
-
                 var cnt = const_(store ? mems : null);
                 if (cnt) {
                     cnt.extAttrs = ea;

--- a/lib/webidl2.js
+++ b/lib/webidl2.js
@@ -710,15 +710,19 @@
                     consume(OTHER, ";") || error("Missing semicolon after interface");
                     return ret;
                 }
+
+
                 var ea = extended_attrs(store ? mems : null);
                 all_ws();
+
                 var cnt = const_(store ? mems : null);
                 if (cnt) {
                     cnt.extAttrs = ea;
                     ret.members.push(cnt);
                     continue;
                 }
-                var mem = serialiser(store ? mems : null) ||
+                var mem = (opt.allowNestedTypedefs && typedef(store ? mems : null)) ||
+                          serialiser(store ? mems : null) ||
                           attribute(store ? mems : null) ||
                           operation(store ? mems : null) ||
                           error("Unknown member");

--- a/test/invalid/idl/typedef-nested.widl
+++ b/test/invalid/idl/typedef-nested.widl
@@ -1,0 +1,22 @@
+
+      interface Point {
+        attribute float x;
+        attribute float y;
+      };
+
+
+      interface Rect {
+        attribute Point topleft;
+        attribute Point bottomright;
+      };
+
+  interface Widget {
+    typedef sequence<Point> PointSequence;
+
+    readonly attribute Rect bounds;
+
+    boolean pointWithinBounds(Point p);
+    boolean allPointsWithinBounds(PointSequence ps);
+  };
+
+  typedef [Clamp] octet value; 

--- a/test/invalid/json/typedef-nested.json
+++ b/test/invalid/json/typedef-nested.json
@@ -1,0 +1,4 @@
+{
+    "message":  "Invalid operation"
+,   "line":     14
+}

--- a/test/syntax.js
+++ b/test/syntax.js
@@ -17,11 +17,16 @@ describe("Parses all of the IDLs to produce the correct ASTs", function () {
     
     for (var i = 0, n = idls.length; i < n; i++) {
         var idl = idls[i], json = jsons[i];
+
         var func = (function (idl, json) {
             return function () {
                 try {
+                    var optFile = pth.join(__dirname, "syntax/opt", pth.basename(json));
+                    var opt = undefined;
+                    if (fs.existsSync(optFile))
+                        opt = JSON.parse(fs.readFileSync(optFile, "utf8"));
                     var diff = jdp.diff(JSON.parse(fs.readFileSync(json, "utf8")),
-                                        wp.parse(fs.readFileSync(idl, "utf8")));
+                                        wp.parse(fs.readFileSync(idl, "utf8"), opt));
                     if (diff && debug) console.log(JSON.stringify(diff, null, 4));
                     expect(diff).to.be(undefined);
                 }

--- a/test/syntax/idl/typedef-nested.widl
+++ b/test/syntax/idl/typedef-nested.widl
@@ -1,0 +1,22 @@
+
+      interface Point {
+        attribute float x;
+        attribute float y;
+      };
+
+
+      interface Rect {
+        attribute Point topleft;
+        attribute Point bottomright;
+      };
+
+  interface Widget {
+    typedef sequence<Point> PointSequence;
+
+    readonly attribute Rect bounds;
+
+    boolean pointWithinBounds(Point p);
+    boolean allPointsWithinBounds(PointSequence ps);
+  };
+
+  typedef [Clamp] octet value; 

--- a/test/syntax/json/typedef-nested.json
+++ b/test/syntax/json/typedef-nested.json
@@ -1,0 +1,226 @@
+[
+    {
+        "type": "interface",
+        "name": "Point",
+        "partial": false,
+        "members": [
+            {
+                "type": "attribute",
+                "static": false,
+                "stringifier": false,
+                "inherit": false,
+                "readonly": false,
+                "idlType": {
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "array": false,
+                    "union": false,
+                    "idlType": "float"
+                },
+                "name": "x",
+                "extAttrs": []
+            },
+            {
+                "type": "attribute",
+                "static": false,
+                "stringifier": false,
+                "inherit": false,
+                "readonly": false,
+                "idlType": {
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "array": false,
+                    "union": false,
+                    "idlType": "float"
+                },
+                "name": "y",
+                "extAttrs": []
+            }
+        ],
+        "inheritance": null,
+        "extAttrs": []
+    },
+    {
+        "type": "interface",
+        "name": "Rect",
+        "partial": false,
+        "members": [
+            {
+                "type": "attribute",
+                "static": false,
+                "stringifier": false,
+                "inherit": false,
+                "readonly": false,
+                "idlType": {
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "array": false,
+                    "union": false,
+                    "idlType": "Point"
+                },
+                "name": "topleft",
+                "extAttrs": []
+            },
+            {
+                "type": "attribute",
+                "static": false,
+                "stringifier": false,
+                "inherit": false,
+                "readonly": false,
+                "idlType": {
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "array": false,
+                    "union": false,
+                    "idlType": "Point"
+                },
+                "name": "bottomright",
+                "extAttrs": []
+            }
+        ],
+        "inheritance": null,
+        "extAttrs": []
+    },
+    {
+        "type": "interface",
+        "name": "Widget",
+        "partial": false,
+        "members": [
+            {
+                "type": "typedef",
+                "typeExtAttrs": [],
+                "idlType": {
+                    "sequence": true,
+                    "generic": "sequence",
+                    "nullable": false,
+                    "array": false,
+                    "union": false,
+                    "idlType": {
+                        "sequence": false,
+                        "generic": null,
+                        "nullable": false,
+                        "array": false,
+                        "union": false,
+                        "idlType": "Point"
+                    }
+                },
+                "name": "PointSequence",
+                "extAttrs": []
+            },
+            {
+                "type": "attribute",
+                "static": false,
+                "stringifier": false,
+                "inherit": false,
+                "readonly": true,
+                "idlType": {
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "array": false,
+                    "union": false,
+                    "idlType": "Rect"
+                },
+                "name": "bounds",
+                "extAttrs": []
+            },
+            {
+                "type": "operation",
+                "getter": false,
+                "setter": false,
+                "creator": false,
+                "deleter": false,
+                "legacycaller": false,
+                "static": false,
+                "stringifier": false,
+                "idlType": {
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "array": false,
+                    "union": false,
+                    "idlType": "boolean"
+                },
+                "name": "pointWithinBounds",
+                "arguments": [
+                    {
+                        "optional": false,
+                        "variadic": false,
+                        "extAttrs": [],
+                        "idlType": {
+                            "sequence": false,
+                            "generic": null,
+                            "nullable": false,
+                            "array": false,
+                            "union": false,
+                            "idlType": "Point"
+                        },
+                        "name": "p"
+                    }
+                ],
+                "extAttrs": []
+            },
+            {
+                "type": "operation",
+                "getter": false,
+                "setter": false,
+                "creator": false,
+                "deleter": false,
+                "legacycaller": false,
+                "static": false,
+                "stringifier": false,
+                "idlType": {
+                    "sequence": false,
+                    "generic": null,
+                    "nullable": false,
+                    "array": false,
+                    "union": false,
+                    "idlType": "boolean"
+                },
+                "name": "allPointsWithinBounds",
+                "arguments": [
+                    {
+                        "optional": false,
+                        "variadic": false,
+                        "extAttrs": [],
+                        "idlType": {
+                            "sequence": false,
+                            "generic": null,
+                            "nullable": false,
+                            "array": false,
+                            "union": false,
+                            "idlType": "PointSequence"
+                        },
+                        "name": "ps"
+                    }
+                ],
+                "extAttrs": []
+            }
+        ],
+        "inheritance": null,
+        "extAttrs": []
+    },
+    {
+        "type": "typedef",
+        "typeExtAttrs": [
+            {
+                "name": "Clamp",
+                "arguments": null
+            }
+        ],
+        "idlType": {
+            "sequence": false,
+            "generic": null,
+            "nullable": false,
+            "array": false,
+            "union": false,
+            "idlType": "octet"
+        },
+        "name": "value",
+        "extAttrs": []
+    }
+]

--- a/test/syntax/opt/typedef-nested.json
+++ b/test/syntax/opt/typedef-nested.json
@@ -1,0 +1,3 @@
+{
+    "allowNestedTypedefs": true
+}


### PR DESCRIPTION
### Motivation
The [official WebGL spec](https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl) contains a few of these:

```WebIDL
interface WebGL2RenderingContextBase
{
  //... 

  typedef (Uint32Array or sequence<GLuint>) UniformUIVSource;

  //... 
}
```
As far as I can tell, this is technically invalid Web IDL. However, I would like to be able to consume the official WebGL spec with no changes... Hence this PR.

### What's in this PR
I've added the following proposed usage of `parse()`:
```javascript
parse(..., {allowNestedTypedefs: true}) // Accept typedefs as valid members of interfaces
parse(...) // Works like before
```
Tests for both cases are included. Tangentially, there's also the infrastructure to configure the parser on a per-testcase basis, using JSON option files under `test/syntax/opt`, [like I did for `typedef-nested.widl`](https://github.com/motiz88/webidl2.js/commit/decd1c02c8c1579241a0b7a3ed427955ff0bb6fc).